### PR TITLE
Open selection in new tab and make "--dont-load-files" optional

### DIFF
--- a/src/GoToDnSpy/GoToDnSpy.cs
+++ b/src/GoToDnSpy/GoToDnSpy.cs
@@ -155,6 +155,7 @@ namespace GoToDnSpy
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 _statusBar.SetText("");
                 var dnSpyPath = ReadDnSpyPath()?.Trim(_pathTrimChars);
+                var loadPrevious = ReadLoadPrevious();
                 if (string.IsNullOrWhiteSpace(dnSpyPath))
                 {
                     MessageBox.Show("You must specify dnSpy path in options", "[GoToDnSpy] Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -269,7 +270,7 @@ namespace GoToDnSpy
                         return;
                     }
                 }
-                System.Diagnostics.Process.Start(dnSpyPath, BuildDnSpyArguments(asmPath, typeName, memberName, memberType));
+                System.Diagnostics.Process.Start(dnSpyPath, BuildDnSpyArguments(asmPath, typeName, memberName, memberType, loadPrevious));
 
             }
             catch (Exception ex)
@@ -380,9 +381,11 @@ namespace GoToDnSpy
 
         private string ReadDnSpyPath() => ((SettingsDialog)_package.GetDialogPage(typeof(SettingsDialog)))?.DnSpyPath;
 
-        private static string BuildDnSpyArguments(string asmPath, string typeName, string memberName, MemberType memberType)
+        private bool ReadLoadPrevious() => ((SettingsDialog)_package.GetDialogPage(typeof(SettingsDialog))).LoadPrevious;
+
+        private static string BuildDnSpyArguments(string asmPath, string typeName, string memberName, MemberType memberType, bool loadPrevious)
         {
-            string result = $"\"{asmPath}\" --dont-load-files --select {(memberName == null ? 'T' : memberType.ToString()[0])}:{typeName}";
+            string result = $"\"{asmPath}\" {(loadPrevious ? "" : "--dont-load-files")} --new-tab --select {(memberName == null ? 'T' : memberType.ToString()[0])}:{typeName}";
             if (memberName != null)
                 result = $"{result}.{memberName}";
             return result;

--- a/src/GoToDnSpy/SettingsDialog.cs
+++ b/src/GoToDnSpy/SettingsDialog.cs
@@ -18,6 +18,11 @@ namespace GoToDnSpy
         [Description("Path to dnSpy.exe. Example: C:\\dnSpy\\dnSpy.exe")]
         public string DnSpyPath { get; set;}
 
+        [Category("GoTo dnSpy")]
+        [DisplayName("Load previous list")]
+        [Description("Whether or not to load files other than those related to the selection, if a new process is started")]
+        public bool LoadPrevious { get; set; } = true;
+
         /// <summary>
         /// Mode was added recently in new version <see cref="DialogPage"/> ?
         /// So this is workaround for removing it from settings property grid


### PR DESCRIPTION
This change creates a new option specifying whether or not to reopen files from the last loaded list if a new instance of dnSpy is started, something that is currently disabled by default. It also makes selections open in a new tab.